### PR TITLE
Fix desktop shortcut

### DIFF
--- a/portainer.desktop
+++ b/portainer.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Name=Portainer
 Comment=A lightweight docker management UI
-Exec=xdg-open http://localhost:9443
+Exec=xdg-open https://localhost:9443
 Icon=portainer
 Type=Application
 Categories=GNOME;GTK;System;Utility;


### PR DESCRIPTION
The created desktop entry opens the browser as expected, however it will show an error:

"Client sent an HTTP request to an HTTPS server."

Changing the URL to HTTPS fixes the issue for me.